### PR TITLE
change compile to api

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++11"
-                abiFilters 'x86_64', 'arm64-v8a', 'armeabi-v7a'
+                abiFilters 'x86', 'x86_64', 'arm64-v8a', 'armeabi-v7a'
             }
         }
         sourceSets {

--- a/app/src/main/cpp/neoterm.cpp
+++ b/app/src/main/cpp/neoterm.cpp
@@ -7,6 +7,8 @@
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <termios.h>
+#include <unistd.h>
+#include <string.h>
 
 #define __neoterm_no_return __attribute__((__noreturn__))
 

--- a/chrome-tabs/build.gradle
+++ b/chrome-tabs/build.gradle
@@ -22,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile 'com.github.michael-rapp:android-util:1.15.0'
+    api 'com.github.michael-rapp:android-util:1.15.0'
     implementation rootProject.ext.deps["annotations"]
     implementation rootProject.ext.deps["appcompat-v7"]
     testImplementation rootProject.ext.deps["junit"]


### PR DESCRIPTION
Because compile does not work now in android studio.
And when I replace compile with implementation then a dependencies problem arises.